### PR TITLE
Remove extra call to ConstructSDandField()

### DIFF
--- a/src/CaliceDetectorConstruction.cc
+++ b/src/CaliceDetectorConstruction.cc
@@ -30,7 +30,6 @@ CaliceDetectorConstruction::CaliceDetectorConstruction(const G4GDMLParser& parse
 //
 G4VPhysicalVolume* CaliceDetectorConstruction::Construct() {
     
-    ConstructSDandField();
     return fParser.GetWorldVolume();
 
 }


### PR DESCRIPTION
- Removes the extra call to the method that is already invoked by the kernel. It fixes the G4Exception issued by G4SDStructure (e34b08e).